### PR TITLE
fix potential null reference on pending messages

### DIFF
--- a/cpp2sky/internal/async_client.h
+++ b/cpp2sky/internal/async_client.h
@@ -47,7 +47,7 @@ class AsyncClient {
   /**
    * Send the specified protobuf message
    */
-  virtual void sendMessage(Message& message) = 0;
+  virtual void sendMessage(RequestType message) = 0;
 
   /**
    * Get writer.
@@ -69,9 +69,10 @@ enum class Operation : uint8_t {
   Finished = 4,
 };
 
-template <class RequsetType, class ResponseType>
-using AsyncClientPtr = std::unique_ptr<AsyncClient<RequsetType, ResponseType>>;
+template <class RequestType, class ResponseType>
+using AsyncClientPtr = std::unique_ptr<AsyncClient<RequestType, ResponseType>>;
 
+template <class RequestType>
 class AsyncStream {
  public:
   virtual ~AsyncStream() = default;
@@ -84,7 +85,7 @@ class AsyncStream {
   /**
    * Send message. It will move the state from Init to Write.
    */
-  virtual void sendMessage(Message& message) = 0;
+  virtual void sendMessage(RequestType message) = 0;
 
   /**
    * Handle incoming event related to this stream.
@@ -92,7 +93,8 @@ class AsyncStream {
   virtual bool handleOperation(Operation incoming_op) = 0;
 };
 
-using AsyncStreamPtr = std::shared_ptr<AsyncStream>;
+template <class RequestType>
+using AsyncStreamPtr = std::shared_ptr<AsyncStream<RequestType>>;
 
 template <class RequestType, class ResponseType>
 class AsyncStreamFactory {
@@ -102,7 +104,7 @@ class AsyncStreamFactory {
   /**
    * Create async stream entity
    */
-  virtual AsyncStreamPtr create(
+  virtual AsyncStreamPtr<RequestType> create(
       AsyncClient<RequestType, ResponseType>* client) = 0;
 };
 

--- a/source/grpc_async_client_impl.cc
+++ b/source/grpc_async_client_impl.cc
@@ -42,7 +42,7 @@ GrpcAsyncSegmentReporterClient::GrpcAsyncSegmentReporterClient(
   stream_->startStream();
 }
 
-void GrpcAsyncSegmentReporterClient::sendMessage(Message& message) {
+void GrpcAsyncSegmentReporterClient::sendMessage(TracerRequestType message) {
   GPR_ASSERT(stream_ != nullptr);
   stream_->sendMessage(message);
 }
@@ -76,7 +76,7 @@ bool GrpcAsyncSegmentReporterStream::startStream() {
   return true;
 }
 
-void GrpcAsyncSegmentReporterStream::sendMessage(Message& message) {
+void GrpcAsyncSegmentReporterStream::sendMessage(TracerRequestType message) {
   pending_messages_.emplace(message);
   clearPendingMessages();
 }
@@ -87,9 +87,7 @@ bool GrpcAsyncSegmentReporterStream::clearPendingMessages() {
   }
   auto message = pending_messages_.back();
   pending_messages_.pop();
-  TracerRequestType obj;
-  obj.CopyFrom(message.get());
-  request_writer_->Write(obj, toTag(&write_done_));
+  request_writer_->Write(message, toTag(&write_done_));
   return true;
 }
 
@@ -98,7 +96,7 @@ bool GrpcAsyncSegmentReporterStream::handleOperation(Operation incoming_op) {
   while (true) {
     if (state_ == Operation::Connected) {
       gpr_log(GPR_INFO, "Established connection: %s",
-        client_->peerAddress().c_str());
+              client_->peerAddress().c_str());
       state_ = Operation::Idle;
     } else if (state_ == Operation::WriteDone) {
       state_ = Operation::Idle;
@@ -122,7 +120,7 @@ bool GrpcAsyncSegmentReporterStream::handleOperation(Operation incoming_op) {
   }
 }
 
-AsyncStreamPtr GrpcAsyncSegmentReporterStreamFactory::create(
+AsyncStreamPtr<TracerRequestType> GrpcAsyncSegmentReporterStreamFactory::create(
     AsyncClient<TracerRequestType, TracerResponseType>* client) {
   if (client == nullptr) {
     return nullptr;

--- a/test/grpc_async_client_test.cc
+++ b/test/grpc_async_client_test.cc
@@ -37,7 +37,8 @@ class GrpcAsyncSegmentReporterClientTest : public testing::Test {
  protected:
   grpc::CompletionQueue cq_;
   std::string address_{"localhost:50051"};
-  std::shared_ptr<MockAsyncStream> stream_{std::make_shared<MockAsyncStream>()};
+  std::shared_ptr<MockAsyncStream<TracerRequestType>> stream_{
+      std::make_shared<MockAsyncStream<TracerRequestType>>()};
   MockAsyncStreamFactory<TracerRequestType, TracerResponseType> factory_{
       stream_};
   std::unique_ptr<GrpcAsyncSegmentReporterClient> client_;

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -31,10 +31,11 @@ class MockRandomGenerator : public RandomGenerator {
   MOCK_METHOD(std::string, uuid, ());
 };
 
-class MockAsyncStream : public AsyncStream {
+template <class RequestType>
+class MockAsyncStream : public AsyncStream<RequestType> {
  public:
   MOCK_METHOD(bool, startStream, ());
-  MOCK_METHOD(void, sendMessage, (Message&));
+  MOCK_METHOD(void, sendMessage, (RequestType));
   MOCK_METHOD(std::string, peerAddress, ());
   MOCK_METHOD(bool, handleOperation, (Operation));
 };
@@ -53,13 +54,13 @@ class MockAsyncStreamFactory
     : public AsyncStreamFactory<RequestType, ResponseType> {
  public:
   using AsyncClientType = AsyncClient<RequestType, ResponseType>;
-  MockAsyncStreamFactory(AsyncStreamPtr stream) : stream_(stream) {
+  MockAsyncStreamFactory(AsyncStreamPtr<RequestType> stream) : stream_(stream) {
     ON_CALL(*this, create(_)).WillByDefault(Return(stream_));
   }
-  MOCK_METHOD(AsyncStreamPtr, create, (AsyncClientType*));
+  MOCK_METHOD(AsyncStreamPtr<RequestType>, create, (AsyncClientType*));
 
  private:
-  AsyncStreamPtr stream_;
+  AsyncStreamPtr<RequestType> stream_;
 };
 
 }  // namespace cpp2sky


### PR DESCRIPTION
To push message reference to the pending queue will cause potential crash with null message reference.