### PR TITLE
fix circular buffer pop

### DIFF
--- a/source/utils/circular_buffer.h
+++ b/source/utils/circular_buffer.h
@@ -92,7 +92,7 @@ class CircularBuffer {
 
  private:
   void popInternal() {
-    if (buf_[front_].is_destroyed_) {
+    if (empty() || buf_[front_].is_destroyed_) {
       return;
     }
 

--- a/test/buffer_test.cc
+++ b/test/buffer_test.cc
@@ -42,6 +42,9 @@ class CircularBufferTest : public testing::Test {
 
 TEST_F(CircularBufferTest, Basic) {
   setup(3);
+  for (auto i = 0; i < 1000; ++i) {
+    buf_->pop();
+  }
 
   buf_->push(1);
   buf_->push(2);
@@ -91,6 +94,10 @@ TEST_F(CircularBufferTest, Basic) {
   buf_->pop();
 
   evaluate(0, 2, true);
+
+  for (auto i = 0; i < 1000; ++i) {
+    buf_->pop();
+  }
 }
 
 }  // namespace cpp2sky


### PR DESCRIPTION
Fixed unexpected behavior when no item has inserted and call `pop()`.