### PR TITLE
not to send RST_STREAM from async client

### DIFF
--- a/cpp2sky/internal/async_client.h
+++ b/cpp2sky/internal/async_client.h
@@ -87,7 +87,6 @@ enum class Operation : uint8_t {
   Connected = 1,
   Idle = 2,
   WriteDone = 3,
-  Finished = 4,
 };
 
 template <class RequestType, class ResponseType>
@@ -116,7 +115,7 @@ class AsyncStream {
   /**
    * Handle incoming event related to this stream.
    */
-  virtual bool handleOperation(Operation incoming_op) = 0;
+  virtual void handleOperation(Operation incoming_op) = 0;
 };
 
 template <class RequestType>

--- a/source/grpc_async_client_impl.cc
+++ b/source/grpc_async_client_impl.cc
@@ -82,7 +82,7 @@ GrpcAsyncSegmentReporterClient::~GrpcAsyncSegmentReporterClient() {
   // failed to send message and close stream, then recreate new stream and try
   // to do it. This process will continue forever without sending explicit
   // signal.
-  {
+  if (stream_) {
     std::unique_lock<std::mutex> lck(mux_);
     while (!drained_messages_.empty()) {
       cv_.wait(lck);
@@ -149,9 +149,6 @@ GrpcAsyncSegmentReporterStream::~GrpcAsyncSegmentReporterStream() {
     }
   }
   gpr_log(GPR_INFO, "%ld pending messages drained.", pending_messages_size);
-
-  ctx_.TryCancel();
-  request_writer_->Finish(&status_, toTag(&finish_));
 }
 
 bool GrpcAsyncSegmentReporterStream::startStream() {
@@ -184,7 +181,7 @@ bool GrpcAsyncSegmentReporterStream::clearPendingMessages() {
   return true;
 }
 
-bool GrpcAsyncSegmentReporterStream::handleOperation(Operation incoming_op) {
+void GrpcAsyncSegmentReporterStream::handleOperation(Operation incoming_op) {
   state_ = incoming_op;
   if (state_ == Operation::Connected) {
     gpr_log(GPR_INFO, "Established connection: %s",
@@ -209,16 +206,9 @@ bool GrpcAsyncSegmentReporterStream::handleOperation(Operation incoming_op) {
     if (pending_messages_.empty()) {
       cv_.notify_all();
     }
-    return true;
-  } else if (state_ == Operation::Finished) {
-    gpr_log(GPR_INFO, "Stream closed with http status: %d",
-            grpcStatusToGenericHttpStatus(status_.error_code()));
-    if (!status_.ok()) {
-      gpr_log(GPR_ERROR, "%s", status_.error_message().c_str());
-    }
-    return false;
+  } else {
+    throw TracerException("Unknown stream operation");
   }
-  throw TracerException("Unknown stream operation");
 }
 
 AsyncStreamPtr<TracerRequestType> GrpcAsyncSegmentReporterStreamFactory::create(

--- a/source/grpc_async_client_impl.h
+++ b/source/grpc_async_client_impl.h
@@ -111,7 +111,7 @@ class GrpcAsyncSegmentReporterStream final
   // AsyncStream
   bool startStream() override;
   void sendMessage(TracerRequestType message) override;
-  bool handleOperation(Operation incoming_op) override;
+  void handleOperation(Operation incoming_op) override;
   void undrainMessage(TracerRequestType message) override {
     pending_messages_.push(message);
   }
@@ -121,7 +121,6 @@ class GrpcAsyncSegmentReporterStream final
 
   AsyncClient<TracerRequestType, TracerResponseType>* client_;
   TracerResponseType commands_;
-  grpc::Status status_;
   grpc::ClientContext ctx_;
   std::unique_ptr<grpc::ClientAsyncWriter<TracerRequestType>> request_writer_;
   CircularBuffer<TracerRequestType> pending_messages_{
@@ -130,7 +129,6 @@ class GrpcAsyncSegmentReporterStream final
 
   TaggedStream connected_{Operation::Connected, this};
   TaggedStream write_done_{Operation::WriteDone, this};
-  TaggedStream finish_{Operation::Finished, this};
 
   std::condition_variable& cv_;
 };

--- a/source/tracer_impl.cc
+++ b/source/tracer_impl.cc
@@ -51,11 +51,10 @@ void TracerImpl::run() {
     TaggedStream* t_stream = deTag(got_tag);
     if (!ok) {
       client_->resetStream();
+      client_->startStream();
       continue;
     }
-    if (!t_stream->stream->handleOperation(t_stream->operation)) {
-      client_->startStream();
-    }
+    t_stream->stream->handleOperation(t_stream->operation);
   }
 }
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -39,7 +39,7 @@ class MockAsyncStream : public AsyncStream<RequestType> {
   MOCK_METHOD(bool, startStream, ());
   MOCK_METHOD(void, sendMessage, (RequestType));
   MOCK_METHOD(std::string, peerAddress, ());
-  MOCK_METHOD(bool, handleOperation, (Operation));
+  MOCK_METHOD(void, handleOperation, (Operation));
   MOCK_METHOD(void, undrainMessage, (RequestType));
 };
 


### PR DESCRIPTION
Fix #37.
In the first piece, we don't have to send `RST_STREAM` from client because this SDK must just send trace data. So this SDK don't have to send `->Finish()` and handle `FINISH` state. If stream client received the reset or end signal from OAP server because accidental shutdown, it will drain pending messages and re-establish stream.