### PR TITLE
Partial revert #61

### DIFF
--- a/cpp2sky/BUILD
+++ b/cpp2sky/BUILD
@@ -29,3 +29,18 @@ cc_library(
   ],
   visibility = ["//visibility:public"],
 )
+
+cc_library(
+  name = "cpp2sky_data_interface",
+  hdrs = [
+    "tracing_context.h",
+    "propagation.h",
+    "well_known_names.h",
+    "exception.h",
+    "time.h",
+  ],
+  deps = [
+    ":config_cc_proto",
+  ],
+  visibility = ["//visibility:public"],
+)

--- a/source/BUILD
+++ b/source/BUILD
@@ -65,19 +65,16 @@ cc_library(
 
 cc_library(
   name = "cpp2sky_data_lib",
-  hdrs = [
+  hdrs  =[
     "propagation_impl.h",
     "tracing_context_impl.h",
-    "dynamic_config.h",
   ],
   srcs = [
     "propagation_impl.cc",
     "tracing_context_impl.cc",
   ],
   deps = [
-    "@skywalking_data_collect_protocol//language-agent:configuration_discovery_service_cc_proto",
     "@skywalking_data_collect_protocol//language-agent:tracing_protocol_cc_proto",
-    "@com_google_absl//absl/strings:strings",
     "//cpp2sky:config_cc_proto",
     "//cpp2sky:cpp2sky_interface",
     "//source/utils:util_lib",

--- a/source/BUILD
+++ b/source/BUILD
@@ -76,7 +76,7 @@ cc_library(
   deps = [
     "@skywalking_data_collect_protocol//language-agent:tracing_protocol_cc_proto",
     "//cpp2sky:config_cc_proto",
-    "//cpp2sky:cpp2sky_interface",
+    "//cpp2sky:cpp2sky_data_interface",
     "//source/utils:util_lib",
   ],
   visibility = ["//visibility:public"],

--- a/source/tracer_impl.cc
+++ b/source/tracer_impl.cc
@@ -29,7 +29,7 @@ TracerImpl::TracerImpl(TracerConfig& config,
                        std::shared_ptr<grpc::ChannelCredentials> cred)
     : config_(config),
       grpc_callback_thread_([this] { this->run(); }),
-      segment_factory_(config_) {
+      segment_factory_(config) {
   init(config, cred);
 }
 
@@ -39,7 +39,7 @@ TracerImpl::TracerImpl(
     : config_(config),
       reporter_client_(std::move(reporter_client)),
       grpc_callback_thread_([this] { this->run(); }),
-      segment_factory_(config_) {
+      segment_factory_(config) {
   init(config, nullptr);
 }
 

--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -143,28 +143,37 @@ void TracingSpanImpl::setComponentId(int32_t component_id) {
   component_id_ = component_id;
 }
 
-TracingContextImpl::TracingContextImpl(const DynamicConfig& config,
+TracingContextImpl::TracingContextImpl(const std::string& service_name,
+                                       const std::string& instance_name,
                                        RandomGenerator& random)
     : trace_id_(random.uuid()),
       trace_segment_id_(random.uuid()),
-      config_(config) {}
+      service_(service_name),
+      service_instance_(instance_name) {}
+
 
 TracingContextImpl::TracingContextImpl(
-    const DynamicConfig& config, SpanContextPtr parent_span_context,
+    const std::string& service_name,
+    const std::string& instance_name, SpanContextPtr parent_span_context,
     SpanContextExtensionPtr parent_ext_span_context, RandomGenerator& random)
     : parent_span_context_(std::move(parent_span_context)),
       parent_ext_span_context_(std::move(parent_ext_span_context)),
       trace_id_(parent_span_context_->traceId()),
       trace_segment_id_(random.uuid()),
-      config_(config) {}
+      service_(service_name),
+      service_instance_(instance_name) {}
 
-TracingContextImpl::TracingContextImpl(const DynamicConfig& config,
+
+TracingContextImpl::TracingContextImpl(const std::string& service_name,
+                                       const std::string& instance_name,
                                        SpanContextPtr parent_span_context,
                                        RandomGenerator& random)
     : parent_span_context_(std::move(parent_span_context)),
       trace_id_(parent_span_context_->traceId()),
       trace_segment_id_(random.uuid()),
-      config_(config) {}
+      service_(service_name),
+      service_instance_(instance_name) {}
+
 
 TracingSpanPtr TracingContextImpl::createExitSpan(TracingSpanPtr parent_span) {
   auto current_span = createSpan();
@@ -214,8 +223,8 @@ std::string TracingContextImpl::encodeSpan(
   header_value += Base64::encode(trace_id_) + "-";
   header_value += Base64::encode(trace_segment_id_) + "-";
   header_value += parent_spanid + "-";
-  header_value += Base64::encode(config_.tracerConfig().service_name()) + "-";
-  header_value += Base64::encode(config_.tracerConfig().instance_name()) + "-";
+  header_value += Base64::encode(service_) + "-";
+  header_value += Base64::encode(service_instance_) + "-";
   header_value += Base64::encode(endpoint) + "-";
   header_value += Base64::encode(target_address.data());
 
@@ -240,8 +249,8 @@ skywalking::v3::SegmentObject TracingContextImpl::createSegmentObject() {
 
   obj.set_traceid(trace_id_);
   obj.set_tracesegmentid(trace_segment_id_);
-  obj.set_service(config_.tracerConfig().service_name());
-  obj.set_serviceinstance(config_.tracerConfig().instance_name());
+  obj.set_service(service_);
+  obj.set_serviceinstance(service_instance_);
 
   for (auto& span : spans_) {
     auto* entry = obj.mutable_spans()->Add();
@@ -260,22 +269,24 @@ bool TracingContextImpl::readyToSend() {
   return true;
 }
 
-TracingContextFactory::TracingContextFactory(const DynamicConfig& config)
-    : config_(config) {}
+TracingContextFactory::TracingContextFactory(const TracerConfig& config)
+    : service_name_(config.service_name()), instance_name_(config.instance_name()) {}
 
 TracingContextPtr TracingContextFactory::create() {
-  return std::make_unique<TracingContextImpl>(config_, random_generator_);
+  return std::make_unique<TracingContextImpl>(service_name_, instance_name_,
+                                              random_generator_);
 }
 
 TracingContextPtr TracingContextFactory::create(SpanContextPtr span_context) {
-  return std::make_unique<TracingContextImpl>(config_, span_context,
-                                              random_generator_);
+  return std::make_unique<TracingContextImpl>(service_name_, instance_name_,
+                                              span_context, random_generator_);
 }
 
 TracingContextPtr TracingContextFactory::create(
     SpanContextPtr span_context, SpanContextExtensionPtr ext_span_context) {
   auto context = std::make_unique<TracingContextImpl>(
-      config_, span_context, ext_span_context, random_generator_);
+      service_name_, instance_name_, span_context, ext_span_context,
+      random_generator_);
   if (ext_span_context->tracingMode() == TracingMode::Skip) {
     context->setSkipAnalysis();
   }

--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -151,10 +151,9 @@ TracingContextImpl::TracingContextImpl(const std::string& service_name,
       service_(service_name),
       service_instance_(instance_name) {}
 
-
 TracingContextImpl::TracingContextImpl(
-    const std::string& service_name,
-    const std::string& instance_name, SpanContextPtr parent_span_context,
+    const std::string& service_name, const std::string& instance_name,
+    SpanContextPtr parent_span_context,
     SpanContextExtensionPtr parent_ext_span_context, RandomGenerator& random)
     : parent_span_context_(std::move(parent_span_context)),
       parent_ext_span_context_(std::move(parent_ext_span_context)),
@@ -162,7 +161,6 @@ TracingContextImpl::TracingContextImpl(
       trace_segment_id_(random.uuid()),
       service_(service_name),
       service_instance_(instance_name) {}
-
 
 TracingContextImpl::TracingContextImpl(const std::string& service_name,
                                        const std::string& instance_name,
@@ -173,7 +171,6 @@ TracingContextImpl::TracingContextImpl(const std::string& service_name,
       trace_segment_id_(random.uuid()),
       service_(service_name),
       service_instance_(instance_name) {}
-
 
 TracingSpanPtr TracingContextImpl::createExitSpan(TracingSpanPtr parent_span) {
   auto current_span = createSpan();
@@ -270,7 +267,8 @@ bool TracingContextImpl::readyToSend() {
 }
 
 TracingContextFactory::TracingContextFactory(const TracerConfig& config)
-    : service_name_(config.service_name()), instance_name_(config.instance_name()) {}
+    : service_name_(config.service_name()),
+      instance_name_(config.instance_name()) {}
 
 TracingContextPtr TracingContextFactory::create() {
   return std::make_unique<TracingContextImpl>(service_name_, instance_name_,

--- a/source/tracing_context_impl.h
+++ b/source/tracing_context_impl.h
@@ -132,9 +132,7 @@ class TracingContextImpl : public TracingContext {
   const std::string& traceSegmentId() const override {
     return trace_segment_id_;
   }
-  const std::string& service() const override {
-    return service_;
-  }
+  const std::string& service() const override { return service_; }
   const std::string& serviceInstance() const override {
     return service_instance_;
   }

--- a/test/tracing_context_test.cc
+++ b/test/tracing_context_test.cc
@@ -43,12 +43,10 @@ class TracingContextTest : public testing::Test {
     span_ctx_ = std::make_shared<SpanContextImpl>(sample_ctx);
     span_ext_ctx_ = std::make_shared<SpanContextExtensionImpl>("1");
 
-    dy_config_ = std::make_unique<DynamicConfig>(config_);
-    factory_ = std::make_unique<TracingContextFactory>(*dy_config_);
+    factory_ = std::make_unique<TracingContextFactory>(config_);
   }
 
  protected:
-  std::unique_ptr<DynamicConfig> dy_config_;
   NiceMock<MockRandomGenerator> random_;
   std::string service_name_ = "mesh";
   std::string instance_name_ = "service_0";
@@ -289,7 +287,8 @@ TEST_F(TracingContextTest, SkipAnalysisSegment) {
 }
 
 TEST_F(TracingContextTest, SW8CreateTest) {
-  TracingContextImpl sc(*dy_config_, span_ctx_, span_ext_ctx_, random_);
+  TracingContextImpl sc(config_.service_name(), config_.instance_name(),
+                        span_ctx_, span_ext_ctx_, random_);
   EXPECT_EQ(sc.service(), "mesh");
   EXPECT_EQ(sc.serviceInstance(), "service_0");
 


### PR DESCRIPTION
The changes in `tracing_context_impl.h` are no longer needed because `instance_name` is not a target of CDS. This PR does partial revert of that change. 