### PR TITLE
reporter endpoint backward compat

### DIFF
--- a/cpp2sky/internal/async_client.h
+++ b/cpp2sky/internal/async_client.h
@@ -126,6 +126,8 @@ struct StreamCallbackTag {
       case StreamState::ReadDone:
         callback_->onReadDone();
         break;
+      default:
+        break;
     }
   }
 

--- a/example/BUILD
+++ b/example/BUILD
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 cc_binary(
-  name = "tracer_example",
+  name = "sample",
   srcs = ["sample.cc"],
   deps = [
     "//cpp2sky:cpp2sky_interface",
@@ -11,7 +11,7 @@ cc_binary(
 )
 
 cc_binary(
-  name = "tracer_client_example",
+  name = "sample_client",
   srcs = ["sample_client.cc"],
   deps = [
     "//cpp2sky:cpp2sky_interface",

--- a/source/grpc_async_client_impl.cc
+++ b/source/grpc_async_client_impl.cc
@@ -117,8 +117,7 @@ GrpcAsyncSegmentReporterStream::GrpcAsyncSegmentReporterStream(
   ctx_.set_wait_for_ready(true);
 
   request_writer_ = client_.stub().PrepareCall(
-      &ctx_, "/skywalking.v3.TraceSegmentReportService/collect",
-      &client_.completionQueue());
+      &ctx_, "/TraceSegmentReportService/collect", &client_.completionQueue());
   request_writer_->StartCall(reinterpret_cast<void*>(&ready_));
 }
 

--- a/source/propagation_impl.cc
+++ b/source/propagation_impl.cc
@@ -36,7 +36,7 @@ SpanContextImpl::SpanContextImpl(std::string_view header_value) {
   size_t current_field_idx = 0;
   std::string value;
 
-  for (auto i = 0; i < header_value.size(); ++i) {
+  for (size_t i = 0; i < header_value.size(); ++i) {
     if (current_field_idx >= EXPECTED_FIELD_COUNT) {
       throw TracerException(
           "Invalid span context format. It must have 8 fields.");
@@ -78,7 +78,7 @@ SpanContextExtensionImpl::SpanContextExtensionImpl(
   size_t current_field_idx = 0;
   std::string value;
 
-  for (auto i = 0; i < header_value.size(); ++i) {
+  for (size_t i = 0; i < header_value.size(); ++i) {
     if (current_field_idx >= EXPECTED_EXTENSION_FIELD_COUNT) {
       throw TracerException(
           "Invalid span context format. It must have 1 fields.");

--- a/source/tracing_context_impl.h
+++ b/source/tracing_context_impl.h
@@ -27,7 +27,6 @@ class TracingSpanImpl : public TracingSpan {
 
   skywalking::v3::SpanObject createSpanObject() override;
 
-#pragma region Getters
   int32_t spanId() const override { return span_id_; }
   int32_t parentSpanId() const override { return parent_span_id_; }
   int64_t startTime() const override { return start_time_; }
@@ -47,9 +46,7 @@ class TracingSpanImpl : public TracingSpan {
   }
   bool finished() const override { return finished_; }
   std::string operationName() const override { return operation_name_; }
-#pragma endregion
 
-#pragma region Setters
   void setParentSpanId(int32_t span_id) override {
     assert(!finished_);
     parent_span_id_ = span_id;
@@ -86,7 +83,6 @@ class TracingSpanImpl : public TracingSpan {
   void addLog(std::string key, std::string value,
               TimePoint<SteadyTime> current_time) override;
   void setComponentId(int32_t component_id) override;
-#pragma endregion
 
  private:
   // Based on
@@ -127,7 +123,6 @@ class TracingContextImpl : public TracingContext {
                      SpanContextExtensionPtr parent_ext_span_context,
                      RandomGenerator& random);
 
-#pragma region Getters
   const std::string& traceId() const override { return trace_id_; }
   const std::string& traceSegmentId() const override {
     return trace_segment_id_;
@@ -143,7 +138,6 @@ class TracingContextImpl : public TracingContext {
   SpanContextExtensionPtr parentSpanContextExtension() const override {
     return parent_ext_span_context_;
   }
-#pragma endregion
 
   TracingSpanPtr createExitSpan(TracingSpanPtr parent_span) override;
 

--- a/source/utils/circular_buffer.h
+++ b/source/utils/circular_buffer.h
@@ -86,10 +86,8 @@ class CircularBuffer {
   size_t size() const { return item_count_; }
 
   // Used for test
-#pragma region test
   size_t frontIdx() { return front_; }
   size_t backIdx() { return back_; }
-#pragma endregion
 
  private:
   void popInternal() {

--- a/test/grpc_async_client_test.cc
+++ b/test/grpc_async_client_test.cc
@@ -21,8 +21,6 @@
 #include "source/grpc_async_client_impl.h"
 #include "test/mocks.h"
 
-#define TEST
-
 namespace cpp2sky {
 
 using testing::_;


### PR DESCRIPTION
This change is needed to assure backward compatibility. In previous implementation, all of segment will be reported through `/skywalking.v3.TraceSegmentReportService/collect`. But if we have ~8.3.0, it won't work anymore. To resolve this, use compat endpoint.