### PR TITLE
replace string_view in span context

### DIFF
--- a/cpp2sky/tracing_context.h
+++ b/cpp2sky/tracing_context.h
@@ -88,8 +88,8 @@ class TracingSpan {
   /**
    * Get tags.
    */
-  virtual const std::vector<std::pair<std::string, std::string>>& tags()
-      const = 0;
+  virtual const std::vector<std::pair<std::string_view, std::string_view>>&
+  tags() const = 0;
 
   /**
    * Get logs.
@@ -109,10 +109,10 @@ class TracingSpan {
   /**
    * Set start time to calculate execution time.
    */
-  virtual void startSpan(std::string operation_name) = 0;
-  virtual void startSpan(std::string operation_name,
+  virtual void startSpan(std::string_view operation_name) = 0;
+  virtual void startSpan(std::string_view operation_name,
                          TimePoint<SystemTime> current_time) = 0;
-  virtual void startSpan(std::string operation_name,
+  virtual void startSpan(std::string_view operation_name,
                          TimePoint<SteadyTime> current_time) = 0;
 
   /**
@@ -158,15 +158,15 @@ class TracingSpan {
   /**
    * Set tag to current span.
    */
-  virtual void addTag(std::string key, std::string value) = 0;
+  virtual void addTag(std::string_view key, std::string_view value) = 0;
 
   /**
    * Add log related with current span.
    */
-  virtual void addLog(std::string key, std::string value) = 0;
-  virtual void addLog(std::string key, std::string value,
+  virtual void addLog(std::string_view key, std::string_view value) = 0;
+  virtual void addLog(std::string_view key, std::string_view value,
                       TimePoint<SystemTime> current_time) = 0;
-  virtual void addLog(std::string key, std::string value,
+  virtual void addLog(std::string_view key, std::string_view value,
                       TimePoint<SteadyTime> current_time) = 0;
 
   /**

--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -15,6 +15,7 @@
 #include "source/tracing_context_impl.h"
 
 #include <string>
+#include <string_view>
 
 #include "cpp2sky/exception.h"
 #include "cpp2sky/time.h"
@@ -61,8 +62,8 @@ skywalking::v3::SpanObject TracingSpanImpl::createSpanObject() {
 
   for (auto& tag : tags_) {
     auto* entry = obj.mutable_tags()->Add();
-    entry->set_key(tag.first);
-    entry->set_value(tag.second);
+    entry->set_key(std::string(tag.first));
+    entry->set_value(std::string(tag.second));
   }
 
   for (auto& log : logs_) {
@@ -73,46 +74,46 @@ skywalking::v3::SpanObject TracingSpanImpl::createSpanObject() {
   return obj;
 }
 
-void TracingSpanImpl::addLog(std::string key, std::string value) {
+void TracingSpanImpl::addLog(std::string_view key, std::string_view value) {
   assert(!finished_);
   auto now = TimePoint<SystemTime>();
   addLog(key, value, now);
 }
 
-void TracingSpanImpl::addLog(std::string key, std::string value,
+void TracingSpanImpl::addLog(std::string_view key, std::string_view value,
                              TimePoint<SystemTime> current_time) {
   assert(!finished_);
   skywalking::v3::Log l;
   l.set_time(current_time.fetch());
   auto* entry = l.add_data();
-  entry->set_key(key);
-  entry->set_value(value);
+  entry->set_key(std::string(key));
+  entry->set_value(std::string(value));
   logs_.emplace_back(l);
 }
 
-void TracingSpanImpl::addLog(std::string key, std::string value,
+void TracingSpanImpl::addLog(std::string_view key, std::string_view value,
                              TimePoint<SteadyTime> current_time) {
   assert(!finished_);
   skywalking::v3::Log l;
   l.set_time(current_time.fetch());
   auto* entry = l.add_data();
-  entry->set_key(key);
-  entry->set_value(value);
+  entry->set_key(std::string(key));
+  entry->set_value(std::string(value));
   logs_.emplace_back(l);
 }
 
-void TracingSpanImpl::startSpan(std::string operation_name) {
+void TracingSpanImpl::startSpan(std::string_view operation_name) {
   auto now = TimePoint<SystemTime>();
   startSpan(operation_name, now);
 }
 
-void TracingSpanImpl::startSpan(std::string operation_name,
+void TracingSpanImpl::startSpan(std::string_view operation_name,
                                 TimePoint<SystemTime> current_time) {
   operation_name_ = operation_name;
   start_time_ = current_time.fetch();
 }
 
-void TracingSpanImpl::startSpan(std::string operation_name,
+void TracingSpanImpl::startSpan(std::string_view operation_name,
                                 TimePoint<SteadyTime> current_time) {
   operation_name_ = operation_name;
   start_time_ = current_time.fetch();

--- a/source/tracing_context_impl.h
+++ b/source/tracing_context_impl.h
@@ -14,6 +14,8 @@
 
 #pragma once
 
+#include <string_view>
+
 #include "cpp2sky/config.pb.h"
 #include "cpp2sky/propagation.h"
 #include "cpp2sky/tracing_context.h"
@@ -37,7 +39,7 @@ class TracingSpanImpl : public TracingSpan {
   bool errorStatus() const override { return is_error_; }
   bool skipAnalysis() const override { return skip_analysis_; }
   int32_t componentId() const override { return component_id_; }
-  const std::vector<std::pair<std::string, std::string>>& tags()
+  const std::vector<std::pair<std::string_view, std::string_view>>& tags()
       const override {
     return tags_;
   }
@@ -51,10 +53,10 @@ class TracingSpanImpl : public TracingSpan {
     assert(!finished_);
     parent_span_id_ = span_id;
   }
-  void startSpan(std::string operation_name) override;
-  void startSpan(std::string operation_name,
+  void startSpan(std::string_view operation_name) override;
+  void startSpan(std::string_view operation_name,
                  TimePoint<SystemTime> current_time) override;
-  void startSpan(std::string operation_name,
+  void startSpan(std::string_view operation_name,
                  TimePoint<SteadyTime> current_time) override;
   void endSpan() override;
   void endSpan(TimePoint<SystemTime> current_time) override;
@@ -73,14 +75,14 @@ class TracingSpanImpl : public TracingSpan {
   }
   void setErrorStatus() override { is_error_ = true; }
   void setSkipAnalysis() override { skip_analysis_ = true; }
-  void addTag(std::string key, std::string value) override {
+  void addTag(std::string_view key, std::string_view value) override {
     assert(!finished_);
     tags_.emplace_back(key, value);
   }
-  void addLog(std::string key, std::string value) override;
-  void addLog(std::string key, std::string value,
+  void addLog(std::string_view key, std::string_view value) override;
+  void addLog(std::string_view key, std::string_view value,
               TimePoint<SystemTime> current_time) override;
-  void addLog(std::string key, std::string value,
+  void addLog(std::string_view key, std::string_view value,
               TimePoint<SteadyTime> current_time) override;
   void setComponentId(int32_t component_id) override;
 
@@ -100,7 +102,7 @@ class TracingSpanImpl : public TracingSpan {
   // https://github.com/apache/skywalking/blob/master/docs/en/guides/Component-library-settings.md
   int32_t component_id_ = 9000;
   bool is_error_ = false;
-  std::vector<std::pair<std::string, std::string>> tags_;
+  std::vector<std::pair<std::string_view, std::string_view>> tags_;
   std::vector<skywalking::v3::Log> logs_;
   bool skip_analysis_ = false;
   bool finished_ = false;


### PR DESCRIPTION
This is to resolve this workaround https://github.com/envoyproxy/envoy/pull/16264

Improve `string_view` use for copy avoidance.