### PR TITLE
fix encoding errors caused by string_view that does not end with '\0'

### DIFF
--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -224,7 +224,8 @@ std::string TracingContextImpl::encodeSpan(
   header_value += Base64::encode(service_) + "-";
   header_value += Base64::encode(service_instance_) + "-";
   header_value += Base64::encode(endpoint) + "-";
-  header_value += Base64::encode(target_address.data());
+  header_value +=
+      Base64::encode(target_address.data(), target_address.length());
 
   return header_value;
 }

--- a/test/tracing_context_test.cc
+++ b/test/tracing_context_test.cc
@@ -342,6 +342,26 @@ TEST_F(TracingContextTest, SW8CreateTest) {
       "1-MQ==-dXVpZA==-1-bWVzaA==-c2VydmljZV8w-c2FtcGxlMQ==-MTAuMC4wLjE6NDQz");
 
   EXPECT_EQ(expect_sw8, *sc.createSW8HeaderValue(span2, target_address));
+
+  std::vector<char> target_address_based_vector;
+  target_address_based_vector.reserve(target_address.size() * 2);
+
+  target_address_based_vector = {'1', '0', '.', '0', '.', '0',
+                                 '.', '1', ':', '4', '4', '3'};
+
+  std::string_view target_address_based_vector_view{
+      target_address_based_vector.data(), target_address_based_vector.size()};
+
+  EXPECT_EQ(target_address_based_vector.size(), target_address.size());
+  EXPECT_EQ(expect_sw8,
+            *sc.createSW8HeaderValue(span2, target_address_based_vector_view));
+
+  // Make sure that the end of target_address_based_vector_view is not '\0'. We
+  // reserve enough memory for target_address_based_vector, so push back will
+  // not cause content to be re-allocated.
+  target_address_based_vector.push_back('x');
+  EXPECT_EQ(expect_sw8,
+            *sc.createSW8HeaderValue(span2, target_address_based_vector_view));
 }
 
 TEST_F(TracingContextTest, ReadyToSendTest) {


### PR DESCRIPTION
Signed-off-by: wbpcode <comems@msn.com> / wbphub@live.com

Check #83 get more info. 