### PR TITLE
minor update: use string view as parameter type and remove unnecessary `strlen` in the base64 encode method

### DIFF
--- a/source/utils/base64.h
+++ b/source/utils/base64.h
@@ -30,8 +30,8 @@ class Base64 {
   static std::string encode(const char* input, uint64_t length) {
     return encode(input, length, true);
   }
-  static std::string encode(const std::string& input) {
-    return encode(input.c_str(), strlen(input.c_str()));
+  static std::string encode(std::string_view input) {
+    return encode(input.data(), input.size());
   }
   static std::string decodeWithoutPadding(std::string_view input);
 };


### PR DESCRIPTION
Signed-off-by: wbpcode <wbphub@live.com>

Minor changes of encode method.

1. Remove uncessary strlen in the base64 encode method.
2. Using string view as parameter type of base64 encode method.