### PR TITLE
fix build failed on windows

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,5 +2,6 @@ build --enable_platform_specific_config
 build --features=-supports_dynamic_linker
 build --cxxopt=-std=c++17
 build:windows --cxxopt=-std:c++17
+build:windows --copt=/wd4716
 
 try-import %workspace%/user.bazelrc


### PR DESCRIPTION
Using the current default configuration, build failed on Windows.
![image](https://user-images.githubusercontent.com/5037807/176812584-a78a7d8e-0001-4984-9110-0ee576105152.png)

Errors of the kind "error C4716: 'cpp2sky::GrpcAsyncConfigDiscoveryServiceClient::pendingMessages': must return a value" 
solved by adding --copt=/wd4716 to build:windows in .bazelrc