### PR TITLE
c++11 building support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -2,5 +2,6 @@ build --enable_platform_specific_config
 build --features=-supports_dynamic_linker
 build --cxxopt=-std=c++17
 build:windows --cxxopt=-std:c++17
+build:windows --copt=/wd4716
 
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,7 @@
 build --enable_platform_specific_config
 build --features=-supports_dynamic_linker
+build --copt="-Wall"
+build --copt="-Werror"
 build:windows --copt=/wd4716
 
 try-import %workspace%/user.bazelrc

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,7 +1,5 @@
 build --enable_platform_specific_config
 build --features=-supports_dynamic_linker
-build --cxxopt=-std=c++17
-build:windows --cxxopt=-std:c++17
 build:windows --copt=/wd4716
 
 try-import %workspace%/user.bazelrc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,12 @@ jobs:
         run: |
           sudo wget -O /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-amd64
           sudo chmod +x /usr/local/bin/bazel
-      - name: Run bazel test
+      - name: Run bazel test with c++11
         run: |
-          bazel test //...
+          bazel test --cxxopt=-std=c++0x //...
+      - name: Run bazel test with c++17
+        run: |
+          bazel test --cxxopt=-std=c++17 //...
 
   format:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![cpp2sky test](https://github.com/SkyAPM/cpp2sky/workflows/cpp2sky%20test/badge.svg)
 
-Distributed tracing and monitor SDK in CPP for Apache SkyWalking APM
+Distributed tracing and monitor SDK in CPP for Apache SkyWalking APM. This SDK is compatible with C++ 17, C++ 14, and C++ 11.
 
 ## Build
 
@@ -152,7 +152,7 @@ configurations:
     ignore_suffix: '/ignore, /hoge'
 ```
 
-After setup configurations, try to put values with 
+After setup configurations, try to put values with
 
 ```
 curl --request PUT --data-binary "@./config.yaml" http://localhost:8500/v1/kv/configuration-discovery.default.agentConfigurations

--- a/cpp2sky/BUILD
+++ b/cpp2sky/BUILD
@@ -44,6 +44,9 @@ cc_library(
   ],
   deps = [
     ":config_cc_proto",
+    "@com_google_absl//absl/memory:memory",
+    "@com_google_absl//absl/strings:strings",
+    "@com_google_absl//absl/types:optional",
   ],
   visibility = ["//visibility:public"],
 )

--- a/cpp2sky/assert.h
+++ b/cpp2sky/assert.h
@@ -17,8 +17,10 @@
 namespace cpp2sky {
 
 template <class T>
-static constexpr bool false_v = false;
+class FalseValue {
+  static constexpr bool value = false;
+};
 
-#define CPP2SKY_STATIC_ASSERT(T, m) static_assert(false_v<T>, m)
+#define CPP2SKY_STATIC_ASSERT(T, m) static_assert(FalseValue<T>::value, m)
 
 }  // namespace cpp2sky

--- a/cpp2sky/internal/matcher.h
+++ b/cpp2sky/internal/matcher.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include <memory>
-#include <string_view>
+
+#include "absl/strings/string_view.h"
 
 namespace cpp2sky {
 
@@ -26,7 +27,7 @@ class Matcher {
   /**
    * Check whether to match rule.
    */
-  virtual bool match(std::string_view target) = 0;
+  virtual bool match(absl::string_view target) = 0;
 };
 
 using MatcherPtr = std::unique_ptr<Matcher>;

--- a/cpp2sky/propagation.h
+++ b/cpp2sky/propagation.h
@@ -15,7 +15,8 @@
 #pragma once
 
 #include <memory>
-#include <string_view>
+
+#include "absl/strings/string_view.h"
 
 namespace cpp2sky {
 
@@ -86,8 +87,8 @@ class SpanContextExtension {
 
 using SpanContextExtensionPtr = std::shared_ptr<SpanContextExtension>;
 
-SpanContextPtr createSpanContext(std::string_view ctx);
+SpanContextPtr createSpanContext(absl::string_view ctx);
 
-SpanContextExtensionPtr createSpanContextExtension(std::string_view ctx);
+SpanContextExtensionPtr createSpanContextExtension(absl::string_view ctx);
 
 }  // namespace cpp2sky

--- a/cpp2sky/trace_log.h
+++ b/cpp2sky/trace_log.h
@@ -19,7 +19,6 @@
 #include <type_traits>
 
 #include "absl/strings/string_view.h"
-#include "cpp2sky/assert.h"
 
 namespace cpp2sky {
 
@@ -28,11 +27,9 @@ static constexpr absl::string_view SPDLOG_LOG_FORMAT =
 
 template <class T>
 std::string logFormat() {
-  if constexpr (std::is_same_v<T, spdlog::logger>) {
-    return SPDLOG_LOG_FORMAT.data();
-  } else {
-    CPP2SKY_STATIC_ASSERT(T, "non-supported logger type");
-  }
+  static_assert(std::is_same<T, spdlog::logger>::value,
+                "non-supported logger type");
+  return SPDLOG_LOG_FORMAT.data();
 }
 
 }  // namespace cpp2sky

--- a/cpp2sky/trace_log.h
+++ b/cpp2sky/trace_log.h
@@ -16,14 +16,14 @@
 
 #include <spdlog/logger.h>
 
-#include <string_view>
 #include <type_traits>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/assert.h"
 
 namespace cpp2sky {
 
-static constexpr std::string_view SPDLOG_LOG_FORMAT =
+static constexpr absl::string_view SPDLOG_LOG_FORMAT =
     "{\"level\": \"%^%l%$\", \"msg\": \"%v";
 
 template <class T>

--- a/cpp2sky/tracing_context.h
+++ b/cpp2sky/tracing_context.h
@@ -16,9 +16,10 @@
 
 #include <list>
 #include <memory>
-#include <optional>
-#include <string_view>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/string_view.h"
+#include "absl/types/optional.h"
 #include "cpp2sky/config.pb.h"
 #include "cpp2sky/propagation.h"
 #include "cpp2sky/time.h"
@@ -58,7 +59,7 @@ class TracingSpan {
   /**
    * Get peer address.
    */
-  virtual std::string_view peer() const = 0;
+  virtual absl::string_view peer() const = 0;
 
   /**
    * Get span type.
@@ -88,7 +89,7 @@ class TracingSpan {
   /**
    * Get operation name.
    */
-  virtual std::string_view operationName() const = 0;
+  virtual absl::string_view operationName() const = 0;
 
   /**
    * Set parent span ID of this span.
@@ -98,10 +99,10 @@ class TracingSpan {
   /**
    * Set start time to calculate execution time.
    */
-  virtual void startSpan(std::string_view operation_name) = 0;
-  virtual void startSpan(std::string_view operation_name,
+  virtual void startSpan(absl::string_view operation_name) = 0;
+  virtual void startSpan(absl::string_view operation_name,
                          TimePoint<SystemTime> current_time) = 0;
-  virtual void startSpan(std::string_view operation_name,
+  virtual void startSpan(absl::string_view operation_name,
                          TimePoint<SteadyTime> current_time) = 0;
 
   /**
@@ -114,7 +115,7 @@ class TracingSpan {
   /**
    * Set peer address for this span (lvalue)
    */
-  virtual void setPeer(std::string_view remote_address) = 0;
+  virtual void setPeer(absl::string_view remote_address) = 0;
 
   /**
    * Set span type. Entry or Exit. Entry span means origin span which doesn't
@@ -142,15 +143,15 @@ class TracingSpan {
   /**
    * Set tag to current span.
    */
-  virtual void addTag(std::string_view key, std::string_view value) = 0;
+  virtual void addTag(absl::string_view key, absl::string_view value) = 0;
 
   /**
    * Add log related with current span.
    */
-  virtual void addLog(std::string_view key, std::string_view value) = 0;
-  virtual void addLog(std::string_view key, std::string_view value,
+  virtual void addLog(absl::string_view key, absl::string_view value) = 0;
+  virtual void addLog(absl::string_view key, absl::string_view value,
                       TimePoint<SystemTime> current_time) = 0;
-  virtual void addLog(std::string_view key, std::string_view value,
+  virtual void addLog(absl::string_view key, absl::string_view value,
                       TimePoint<SteadyTime> current_time) = 0;
 
   /**
@@ -161,7 +162,7 @@ class TracingSpan {
   /**
    * Set operation name.
    */
-  virtual void setOperationName(std::string_view operation_name) = 0;
+  virtual void setOperationName(absl::string_view operation_name) = 0;
 
   /**
    * Add parent segment reference to current span.
@@ -231,8 +232,8 @@ class TracingContext {
    * @param target_address Target address to send request. For more detail:
    * https://github.com/apache/skywalking-data-collect-protocol/blob/master/language-agent/Tracing.proto#L97-L101
    */
-  virtual std::optional<std::string> createSW8HeaderValue(
-      const std::string_view target_address) = 0;
+  virtual absl::optional<std::string> createSW8HeaderValue(
+      const absl::string_view target_address) = 0;
 
   /**
    * Generate Apache SkyWalking native segment object. This method **SHOULD**
@@ -260,7 +261,7 @@ class TracingContext {
    * logging format following with any format extracted with
    * cpp2sky::logFormat().
    */
-  virtual std::string logMessage(std::string_view message) const = 0;
+  virtual std::string logMessage(absl::string_view message) const = 0;
 };
 
 using TracingContextPtr = std::shared_ptr<TracingContext>;
@@ -272,7 +273,7 @@ using TracingContextPtr = std::shared_ptr<TracingContext>;
 class StartEntrySpan {
  public:
   StartEntrySpan(TracingContextPtr tracing_context,
-                 std::string_view operation_name)
+                 absl::string_view operation_name)
       : span_(tracing_context->createEntrySpan()) {
     span_->startSpan(operation_name.data());
   }
@@ -291,7 +292,7 @@ class StartEntrySpan {
 class StartExitSpan {
  public:
   StartExitSpan(TracingContextPtr tracing_context, TracingSpanPtr parent_span,
-                std::string_view operation_name)
+                absl::string_view operation_name)
       : span_(tracing_context->createExitSpan(parent_span)) {
     span_->startSpan(operation_name.data());
   }

--- a/cpp2sky/well_known_names.h
+++ b/cpp2sky/well_known_names.h
@@ -14,11 +14,11 @@
 
 #pragma once
 
-#include <string_view>
+#include "absl/strings/string_view.h"
 
 namespace cpp2sky {
 
-static constexpr std::string_view kPropagationHeader = "sw8";
-static constexpr std::string_view kPropagationExtensionHeader = "sw8-x";
+static constexpr absl::string_view kPropagationHeader = "sw8";
+static constexpr absl::string_view kPropagationExtensionHeader = "sw8-x";
 
 }  // namespace cpp2sky

--- a/source/BUILD
+++ b/source/BUILD
@@ -47,6 +47,7 @@ cc_library(
     "tracing_context_impl.cc",
   ],
   deps = [
+    "@com_google_absl//absl/memory:memory",
     "@skywalking_data_collect_protocol//language-agent:tracing_protocol_cc_proto",
     "//cpp2sky:config_cc_proto",
     "//cpp2sky:cpp2sky_data_interface",

--- a/source/cds_impl.h
+++ b/source/cds_impl.h
@@ -36,7 +36,7 @@ class GrpcAsyncConfigDiscoveryServiceClient final
       std::shared_ptr<grpc::ChannelCredentials> cred);
   ~GrpcAsyncConfigDiscoveryServiceClient();
 
-  void sendMessage(CdsRequest request);
+  void sendMessage(CdsRequest request) override;
   void startStream() override {}
   CircularBuffer<CdsRequest>& pendingMessages() override { assert(false); }
   grpc::CompletionQueue& completionQueue() override { return cq_; }
@@ -63,7 +63,7 @@ class GrpcAsyncConfigDiscoveryServiceStream final
       DynamicConfig& config);
 
   // AsyncStream
-  void sendMessage(CdsRequest request);
+  void sendMessage(CdsRequest request) override;
 
   // AsyncStreamCallback
   void onReady() override {}
@@ -80,7 +80,6 @@ class GrpcAsyncConfigDiscoveryServiceStream final
   CdsResponse commands_;
   grpc::Status status_;
   grpc::ClientContext ctx_;
-  StreamState state_{StreamState::Initialized};
   DynamicConfig& config_;
 
   StreamCallbackTag read_done_{StreamState::ReadDone, this};

--- a/source/dynamic_config.cc
+++ b/source/dynamic_config.cc
@@ -23,9 +23,9 @@
 namespace cpp2sky {
 
 namespace {  // well known fields on response commands.
-static constexpr std::string_view UUID_FIELD = "UUID";
-static constexpr std::string_view SERIAL_NUMBER_FIELD = "SerialNumber";
-static constexpr std::string_view IGNORE_SUFFIX = "ignore_suffix";
+static constexpr absl::string_view UUID_FIELD = "UUID";
+static constexpr absl::string_view SERIAL_NUMBER_FIELD = "SerialNumber";
+static constexpr absl::string_view IGNORE_SUFFIX = "ignore_suffix";
 }  // namespace
 
 using namespace spdlog;
@@ -69,12 +69,13 @@ void DynamicConfig::onConfigChange(skywalking::v3::Commands commands) {
            config_.ignore_operation_name_suffix()) {
         will_destroy_suffixes += current_suffix + ",";
       }
-      will_destroy_suffixes = absl::StripSuffix(will_destroy_suffixes, ",");
+      will_destroy_suffixes =
+          std::string(absl::StripSuffix(will_destroy_suffixes, ","));
 
       config_.clear_ignore_operation_name_suffix();
 
       for (const auto& next_suffix : absl::StrSplit(target.value(), ",")) {
-        *config_.add_ignore_operation_name_suffix() = next_suffix;
+        *config_.add_ignore_operation_name_suffix() = std::string(next_suffix);
       }
 
       info("{} updated from {} to {}", IGNORE_SUFFIX.data(),

--- a/source/dynamic_config.h
+++ b/source/dynamic_config.h
@@ -16,8 +16,8 @@
 
 #include <mutex>
 #include <set>
-#include <string_view>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/config.pb.h"
 #include "language-agent/ConfigurationDiscoveryService.pb.h"
 

--- a/source/grpc_async_client_impl.cc
+++ b/source/grpc_async_client_impl.cc
@@ -15,16 +15,16 @@
 #include "grpc_async_client_impl.h"
 
 #include <chrono>
-#include <string_view>
 #include <thread>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/exception.h"
 #include "spdlog/spdlog.h"
 
 namespace cpp2sky {
 
 namespace {
-static constexpr std::string_view authenticationKey = "authentication";
+static constexpr absl::string_view authenticationKey = "authentication";
 }
 
 using namespace spdlog;

--- a/source/matchers/suffix_matcher.cc
+++ b/source/matchers/suffix_matcher.cc
@@ -18,7 +18,7 @@
 
 namespace cpp2sky {
 
-bool SuffixMatcher::match(std::string_view target) {
+bool SuffixMatcher::match(absl::string_view target) {
   for (const auto& ignore_suffix : target_suffixes_) {
     if (absl::EndsWith(target, ignore_suffix)) {
       return true;

--- a/source/matchers/suffix_matcher.h
+++ b/source/matchers/suffix_matcher.h
@@ -25,7 +25,7 @@ class SuffixMatcher : public Matcher {
   explicit SuffixMatcher(std::vector<std::string>&& target_suffixes)
       : target_suffixes_(std::move(target_suffixes)) {}
 
-  bool match(std::string_view target) override;
+  bool match(absl::string_view target) override;
 
  private:
   std::vector<std::string> target_suffixes_;

--- a/source/propagation_impl.cc
+++ b/source/propagation_impl.cc
@@ -15,8 +15,10 @@
 #include "source/propagation_impl.h"
 
 #include <array>
-#include <string_view>
+#include <memory>
 
+#include "absl/memory/memory.h"
+#include "absl/strings/string_view.h"
 #include "cpp2sky/exception.h"
 #include "source/utils/base64.h"
 
@@ -31,7 +33,7 @@ static constexpr size_t EXPECTED_FIELD_COUNT = 8;
 static constexpr size_t EXPECTED_EXTENSION_FIELD_COUNT = 1;
 }  // namespace
 
-SpanContextImpl::SpanContextImpl(std::string_view header_value) {
+SpanContextImpl::SpanContextImpl(absl::string_view header_value) {
   std::array<std::string, EXPECTED_FIELD_COUNT> fields;
   size_t current_field_idx = 0;
   std::string value;
@@ -63,17 +65,19 @@ SpanContextImpl::SpanContextImpl(std::string_view header_value) {
 
   // Sampling is always true
   sample_ = true;
-  trace_id_ = Base64::decodeWithoutPadding(std::string_view(fields[1]));
-  trace_segment_id_ = Base64::decodeWithoutPadding(std::string_view(fields[2]));
+  trace_id_ = Base64::decodeWithoutPadding(absl::string_view(fields[1]));
+  trace_segment_id_ =
+      Base64::decodeWithoutPadding(absl::string_view(fields[2]));
   span_id_ = std::stoi(fields[3]);
-  service_ = Base64::decodeWithoutPadding(std::string_view(fields[4]));
-  service_instance_ = Base64::decodeWithoutPadding(std::string_view(fields[5]));
-  endpoint_ = Base64::decodeWithoutPadding(std::string_view(fields[6]));
-  target_address_ = Base64::decodeWithoutPadding(std::string_view(fields[7]));
+  service_ = Base64::decodeWithoutPadding(absl::string_view(fields[4]));
+  service_instance_ =
+      Base64::decodeWithoutPadding(absl::string_view(fields[5]));
+  endpoint_ = Base64::decodeWithoutPadding(absl::string_view(fields[6]));
+  target_address_ = Base64::decodeWithoutPadding(absl::string_view(fields[7]));
 }
 
 SpanContextExtensionImpl::SpanContextExtensionImpl(
-    std::string_view header_value) {
+    absl::string_view header_value) {
   std::array<std::string, EXPECTED_EXTENSION_FIELD_COUNT> fields;
   size_t current_field_idx = 0;
   std::string value;
@@ -108,12 +112,12 @@ SpanContextExtensionImpl::SpanContextExtensionImpl(
   }
 }
 
-SpanContextPtr createSpanContext(std::string_view ctx) {
-  return std::make_unique<SpanContextImpl>(ctx);
+SpanContextPtr createSpanContext(absl::string_view ctx) {
+  return absl::make_unique<SpanContextImpl>(ctx);
 }
 
-SpanContextExtensionPtr createSpanContextExtension(std::string_view ctx) {
-  return std::make_unique<SpanContextExtensionImpl>(ctx);
+SpanContextExtensionPtr createSpanContextExtension(absl::string_view ctx) {
+  return absl::make_unique<SpanContextExtensionImpl>(ctx);
 }
 
 }  // namespace cpp2sky

--- a/source/propagation_impl.h
+++ b/source/propagation_impl.h
@@ -16,15 +16,15 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/propagation.h"
 
 namespace cpp2sky {
 
 class SpanContextImpl : public SpanContext {
  public:
-  SpanContextImpl(std::string_view header_value);
+  SpanContextImpl(absl::string_view header_value);
 
   bool sample() const override { return sample_; }
   const std::string& traceId() const override { return trace_id_; }
@@ -54,7 +54,7 @@ class SpanContextImpl : public SpanContext {
 
 class SpanContextExtensionImpl : public SpanContextExtension {
  public:
-  SpanContextExtensionImpl(std::string_view header_value);
+  SpanContextExtensionImpl(absl::string_view header_value);
 
   TracingMode tracingMode() const override { return tracing_mode_; }
 

--- a/source/tracer_impl.cc
+++ b/source/tracer_impl.cc
@@ -88,6 +88,8 @@ void TracerImpl::run() {
         continue;
       case grpc::CompletionQueue::SHUTDOWN:
         return;
+      case grpc::CompletionQueue::GOT_EVENT:
+        break;
     }
     static_cast<StreamCallbackTag*>(got_tag)->callback(!ok);
   }

--- a/source/tracer_impl.cc
+++ b/source/tracer_impl.cc
@@ -106,9 +106,9 @@ void TracerImpl::init(TracerConfig& config,
 
   if (reporter_client_ == nullptr) {
     if (config.protocol() == Protocol::GRPC) {
-      reporter_client_ = std::make_unique<GrpcAsyncSegmentReporterClient>(
+      reporter_client_ = absl::make_unique<GrpcAsyncSegmentReporterClient>(
           config.address(), cq_,
-          std::make_unique<GrpcAsyncSegmentReporterStreamBuilder>(
+          absl::make_unique<GrpcAsyncSegmentReporterStreamBuilder>(
               config.token()),
           cred);
     } else {
@@ -116,22 +116,23 @@ void TracerImpl::init(TracerConfig& config,
     }
   }
 
-  op_name_matchers_.emplace_back(std::make_unique<SuffixMatcher>(
+  op_name_matchers_.emplace_back(absl::make_unique<SuffixMatcher>(
       std::vector<std::string>(config.ignore_operation_name_suffix().begin(),
                                config.ignore_operation_name_suffix().end())));
 
   if (config_.tracerConfig().cds_request_interval() != 0) {
-    cds_client_ = std::make_unique<GrpcAsyncConfigDiscoveryServiceClient>(
+    cds_client_ = absl::make_unique<GrpcAsyncConfigDiscoveryServiceClient>(
         config.address(), cq_,
-        std::make_unique<GrpcAsyncConfigDiscoveryServiceStreamBuilder>(config_),
+        absl::make_unique<GrpcAsyncConfigDiscoveryServiceStreamBuilder>(
+            config_),
         cred);
     cds_timer_ =
-        std::make_unique<Timer>(config_.tracerConfig().cds_request_interval());
+        absl::make_unique<Timer>(config_.tracerConfig().cds_request_interval());
   }
 }
 
 TracerPtr createInsecureGrpcTracer(TracerConfig& cfg) {
-  return std::make_unique<TracerImpl>(cfg, grpc::InsecureChannelCredentials());
+  return absl::make_unique<TracerImpl>(cfg, grpc::InsecureChannelCredentials());
 }
 
 }  // namespace cpp2sky

--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -15,8 +15,8 @@
 #include "source/tracing_context_impl.h"
 
 #include <string>
-#include <string_view>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/exception.h"
 #include "cpp2sky/time.h"
 #include "language-agent/Tracing.pb.h"
@@ -35,7 +35,7 @@ TracingSpanImpl::TracingSpanImpl(int32_t span_id,
   span_store_.set_componentid(9000);
 }
 
-void TracingSpanImpl::addLogImpl(std::string_view key, std::string_view value,
+void TracingSpanImpl::addLogImpl(absl::string_view key, absl::string_view value,
                                  int64_t timestamp) {
   assert(!finished_);
   auto* l = span_store_.add_logs();
@@ -45,43 +45,43 @@ void TracingSpanImpl::addLogImpl(std::string_view key, std::string_view value,
   e->set_value(std::string(value));
 }
 
-void TracingSpanImpl::addLog(std::string_view key, std::string_view value) {
+void TracingSpanImpl::addLog(absl::string_view key, absl::string_view value) {
   addLogImpl(key, value, TimePoint<SystemTime>().fetch());
 }
 
-void TracingSpanImpl::addLog(std::string_view key, std::string_view value,
+void TracingSpanImpl::addLog(absl::string_view key, absl::string_view value,
                              TimePoint<SystemTime> current_time) {
   addLogImpl(key, value, current_time.fetch());
 }
 
-void TracingSpanImpl::addLog(std::string_view key, std::string_view value,
+void TracingSpanImpl::addLog(absl::string_view key, absl::string_view value,
                              TimePoint<SteadyTime> current_time) {
   addLogImpl(key, value, current_time.fetch());
 }
 
-void TracingSpanImpl::addTag(std::string_view key, std::string_view value) {
+void TracingSpanImpl::addTag(absl::string_view key, absl::string_view value) {
   assert(!finished_);
   auto* kv = span_store_.add_tags();
   kv->set_key(std::string(key));
   kv->set_value(std::string(value));
 }
 
-void TracingSpanImpl::startSpanImpl(std::string_view operation_name,
+void TracingSpanImpl::startSpanImpl(absl::string_view operation_name,
                                     int64_t timestamp) {
   span_store_.set_operationname(std::string(operation_name));
   span_store_.set_starttime(timestamp);
 }
 
-void TracingSpanImpl::startSpan(std::string_view operation_name) {
+void TracingSpanImpl::startSpan(absl::string_view operation_name) {
   startSpanImpl(operation_name, TimePoint<SystemTime>().fetch());
 }
 
-void TracingSpanImpl::startSpan(std::string_view operation_name,
+void TracingSpanImpl::startSpan(absl::string_view operation_name,
                                 TimePoint<SystemTime> current_time) {
   startSpanImpl(operation_name, current_time.fetch());
 }
 
-void TracingSpanImpl::startSpan(std::string_view operation_name,
+void TracingSpanImpl::startSpan(absl::string_view operation_name,
                                 TimePoint<SteadyTime> current_time) {
   startSpanImpl(operation_name, current_time.fetch());
 }
@@ -113,7 +113,7 @@ void TracingSpanImpl::setComponentId(int32_t component_id) {
   span_store_.set_componentid(component_id);
 }
 
-void TracingSpanImpl::setOperationName(std::string_view name) {
+void TracingSpanImpl::setOperationName(absl::string_view name) {
   assert(!finished_);
   span_store_.set_operationname(std::string(name));
 }
@@ -181,17 +181,17 @@ TracingSpanPtr TracingContextImpl::createEntrySpan() {
   return current_span;
 }
 
-std::optional<std::string> TracingContextImpl::createSW8HeaderValue(
-    const std::string_view target_address) {
+absl::optional<std::string> TracingContextImpl::createSW8HeaderValue(
+    const absl::string_view target_address) {
   auto target_span = spans_.back();
   if (target_span->spanType() != skywalking::v3::SpanType::Exit) {
-    return std::nullopt;
+    return absl::nullopt;
   }
   return encodeSpan(target_span, target_address);
 }
 
 std::string TracingContextImpl::encodeSpan(
-    TracingSpanPtr parent_span, const std::string_view target_address) {
+    TracingSpanPtr parent_span, const absl::string_view target_address) {
   assert(parent_span);
   std::string header_value;
 
@@ -239,7 +239,7 @@ bool TracingContextImpl::readyToSend() {
   return true;
 }
 
-std::string TracingContextImpl::logMessage(std::string_view message) const {
+std::string TracingContextImpl::logMessage(absl::string_view message) const {
   std::string output = message.data();
   output += "\", \"SW_CTX\": [";
   output += "\"" + segment_store_.service() + "\",";
@@ -261,18 +261,18 @@ TracingContextFactory::TracingContextFactory(const TracerConfig& config)
       instance_name_(config.instance_name()) {}
 
 TracingContextPtr TracingContextFactory::create() {
-  return std::make_unique<TracingContextImpl>(service_name_, instance_name_,
-                                              random_generator_);
+  return absl::make_unique<TracingContextImpl>(service_name_, instance_name_,
+                                               random_generator_);
 }
 
 TracingContextPtr TracingContextFactory::create(SpanContextPtr span_context) {
-  return std::make_unique<TracingContextImpl>(service_name_, instance_name_,
-                                              span_context, random_generator_);
+  return absl::make_unique<TracingContextImpl>(service_name_, instance_name_,
+                                               span_context, random_generator_);
 }
 
 TracingContextPtr TracingContextFactory::create(
     SpanContextPtr span_context, SpanContextExtensionPtr ext_span_context) {
-  auto context = std::make_unique<TracingContextImpl>(
+  auto context = absl::make_unique<TracingContextImpl>(
       service_name_, instance_name_, span_context, ext_span_context,
       random_generator_);
   if (ext_span_context->tracingMode() == TracingMode::Skip) {

--- a/source/tracing_context_impl.cc
+++ b/source/tracing_context_impl.cc
@@ -28,8 +28,7 @@ namespace cpp2sky {
 TracingSpanImpl::TracingSpanImpl(int32_t span_id,
                                  TracingContextImpl& parent_tracing_context)
     : span_store_(
-          *parent_tracing_context.segment_store_.mutable_spans()->Add()),
-      parent_tracing_context_(parent_tracing_context) {
+          *parent_tracing_context.segment_store_.mutable_spans()->Add()) {
   span_store_.set_spanid(span_id);
   // Default component id for historical reason.
   span_store_.set_componentid(9000);

--- a/source/tracing_context_impl.h
+++ b/source/tracing_context_impl.h
@@ -97,7 +97,6 @@ class TracingSpanImpl : public TracingSpan {
   // Parent segment owns all span objects and we only keep a ref in the tracing
   // span.
   skywalking::v3::SpanObject& span_store_;
-  TracingContextImpl& parent_tracing_context_;
 };
 
 class TracingContextImpl : public TracingContext {

--- a/source/tracing_context_impl.h
+++ b/source/tracing_context_impl.h
@@ -14,8 +14,7 @@
 
 #pragma once
 
-#include <string_view>
-
+#include "absl/strings/string_view.h"
 #include "cpp2sky/config.pb.h"
 #include "cpp2sky/propagation.h"
 #include "cpp2sky/tracing_context.h"
@@ -38,7 +37,7 @@ class TracingSpanImpl : public TracingSpan {
   int32_t parentSpanId() const override { return span_store_.parentspanid(); }
   int64_t startTime() const override { return span_store_.starttime(); }
   int64_t endTime() const override { return span_store_.endtime(); }
-  std::string_view peer() const override { return span_store_.peer(); }
+  absl::string_view peer() const override { return span_store_.peer(); }
   skywalking::v3::SpanType spanType() const override {
     return span_store_.spantype();
   }
@@ -48,7 +47,7 @@ class TracingSpanImpl : public TracingSpan {
   bool errorStatus() const override { return span_store_.iserror(); }
   bool skipAnalysis() const override { return span_store_.skipanalysis(); }
   int32_t componentId() const override { return span_store_.componentid(); }
-  std::string_view operationName() const override {
+  absl::string_view operationName() const override {
     return span_store_.operationname();
   }
 
@@ -56,15 +55,15 @@ class TracingSpanImpl : public TracingSpan {
     assert(!finished_);
     span_store_.set_parentspanid(span_id);
   }
-  void startSpan(std::string_view operation_name) override;
-  void startSpan(std::string_view operation_name,
+  void startSpan(absl::string_view operation_name) override;
+  void startSpan(absl::string_view operation_name,
                  TimePoint<SystemTime> current_time) override;
-  void startSpan(std::string_view operation_name,
+  void startSpan(absl::string_view operation_name,
                  TimePoint<SteadyTime> current_time) override;
   void endSpan() override;
   void endSpan(TimePoint<SystemTime> current_time) override;
   void endSpan(TimePoint<SteadyTime> current_time) override;
-  void setPeer(std::string_view remote_address) override {
+  void setPeer(absl::string_view remote_address) override {
     assert(!finished_);
     span_store_.set_peer(std::string(remote_address));
   }
@@ -76,20 +75,20 @@ class TracingSpanImpl : public TracingSpan {
   }
   void setErrorStatus() override { span_store_.set_iserror(true); }
   void setSkipAnalysis() override { span_store_.set_skipanalysis(true); }
-  void addTag(std::string_view key, std::string_view value) override;
-  void addLog(std::string_view key, std::string_view value) override;
-  void addLog(std::string_view key, std::string_view value,
+  void addTag(absl::string_view key, absl::string_view value) override;
+  void addLog(absl::string_view key, absl::string_view value) override;
+  void addLog(absl::string_view key, absl::string_view value,
               TimePoint<SystemTime> current_time) override;
-  void addLog(std::string_view key, std::string_view value,
+  void addLog(absl::string_view key, absl::string_view value,
               TimePoint<SteadyTime> current_time) override;
   void setComponentId(int32_t component_id) override;
-  void setOperationName(std::string_view name) override;
+  void setOperationName(absl::string_view name) override;
   void addSegmentRef(const SpanContext& span_context) override;
   bool finished() const override { return finished_; }
 
-  void addLogImpl(std::string_view key, std::string_view value,
+  void addLogImpl(absl::string_view key, absl::string_view value,
                   int64_t timestamp);
-  void startSpanImpl(std::string_view operation_name, int64_t timestamp);
+  void startSpanImpl(absl::string_view operation_name, int64_t timestamp);
   void endSpanImpl(int64_t timestamp);
 
  private:
@@ -139,19 +138,19 @@ class TracingContextImpl : public TracingContext {
   TracingSpanPtr createExitSpan(TracingSpanPtr parent_span) override;
 
   TracingSpanPtr createEntrySpan() override;
-  std::optional<std::string> createSW8HeaderValue(
-      const std::string_view target_address) override;
+  absl::optional<std::string> createSW8HeaderValue(
+      const absl::string_view target_address) override;
   skywalking::v3::SegmentObject createSegmentObject() override;
   void setSkipAnalysis() override { should_skip_analysis_ = true; }
   bool skipAnalysis() override { return should_skip_analysis_; }
   bool readyToSend() override;
-  std::string logMessage(std::string_view message) const override;
+  std::string logMessage(absl::string_view message) const override;
 
  private:
   friend class TracingSpanImpl;
 
   std::string encodeSpan(TracingSpanPtr parent_span,
-                         const std::string_view target_address);
+                         const absl::string_view target_address);
   TracingSpanPtr createSpan();
 
   SpanContextPtr parent_span_context_;

--- a/source/utils/BUILD
+++ b/source/utils/BUILD
@@ -13,6 +13,7 @@ cc_library(
   ],
   deps = [
     "//cpp2sky/internal:random_generator_interface",
+    "@com_google_absl//absl/strings:strings",
   ],
   visibility = ["//visibility:public"],
 )

--- a/source/utils/base64.h
+++ b/source/utils/base64.h
@@ -37,10 +37,10 @@ class Base64 {
 };
 
 // clang-format off
-inline constexpr char CHAR_TABLE[] =
+constexpr char CHAR_TABLE[] =
     "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 
-inline constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
+constexpr unsigned char REVERSE_LOOKUP_TABLE[256] = {
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64,
     64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 64, 62, 64, 64, 64, 63,
     52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 64, 64, 64, 64, 64, 64, 64, 0,  1,  2,  3,  4,  5,  6,

--- a/source/utils/base64.h
+++ b/source/utils/base64.h
@@ -30,10 +30,10 @@ class Base64 {
   static std::string encode(const char* input, uint64_t length) {
     return encode(input, length, true);
   }
-  static std::string encode(std::string_view input) {
+  static std::string encode(absl::string_view input) {
     return encode(input.data(), input.size());
   }
-  static std::string decodeWithoutPadding(std::string_view input);
+  static std::string decodeWithoutPadding(absl::string_view input);
 };
 
 // clang-format off
@@ -163,7 +163,7 @@ inline std::string Base64::encode(const char* input, uint64_t length,
   return ret;
 }
 
-inline std::string Base64::decodeWithoutPadding(std::string_view input) {
+inline std::string Base64::decodeWithoutPadding(absl::string_view input) {
   if (input.empty()) {
     return "";
   }

--- a/source/utils/circular_buffer.h
+++ b/source/utils/circular_buffer.h
@@ -16,7 +16,8 @@
 
 #include <deque>
 #include <mutex>
-#include <optional>
+
+#include "absl/types/optional.h"
 
 namespace cpp2sky {
 
@@ -32,16 +33,16 @@ class CircularBuffer {
 
   struct Buffer {
     T value;
-    bool is_destroyed_ = false;
+    bool is_destroyed_;
   };
 
   /**
    * Get value which inserted older than any other values.
    * It will return nullopt if buffer is empty.
    */
-  std::optional<T> front() {
+  absl::optional<T> front() {
     if (empty()) {
-      return std::nullopt;
+      return absl::nullopt;
     }
     return buf_[front_].value;
   }

--- a/source/utils/random_generator.cc
+++ b/source/utils/random_generator.cc
@@ -89,7 +89,7 @@ std::string RandomGeneratorImpl::uuid() {
 void RandomGeneratorImpl::randomBuffer(char* ch, size_t len) {
   std::random_device engine;
   std::uniform_int_distribution<std::size_t> dist(0, CHARS.size() - 1);
-  for (auto i = 0; i < len; ++i) {
+  for (size_t i = 0; i < len; ++i) {
     ch[i] = CHARS[dist(engine)];
   }
 }

--- a/source/utils/random_generator.h
+++ b/source/utils/random_generator.h
@@ -20,15 +20,15 @@
 #include <cassert>
 #include <random>
 #include <string>
-#include <string_view>
 
+#include "absl/strings/string_view.h"
 #include "cpp2sky/internal/random_generator.h"
 
 namespace cpp2sky {
 
 namespace {
 static constexpr size_t UUID_LENGTH = 36;
-static constexpr std::string_view CHARS =
+static constexpr absl::string_view CHARS =
     "0123456789AaBbCcDdEeFfGgHhIiJjKkLlMmNnOoPpQqRrSsTtUuVvWwXxYyZz";
 }  // namespace
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -46,6 +46,7 @@ cc_test(
     "grpc_async_client_test.cc",
   ],
   deps = [
+    "@com_google_absl//absl/memory:memory",
     "@com_google_googletest//:gtest_main",
     "//source:cpp2sky_lib",
     ":mocks",
@@ -59,6 +60,7 @@ cc_test(
     "buffer_test.cc",
   ],
   deps = [
+    "@com_google_absl//absl/memory:memory",
     "@com_google_googletest//:gtest_main",
     "//source:cpp2sky_lib",
     ":mocks",

--- a/test/BUILD
+++ b/test/BUILD
@@ -72,6 +72,7 @@ cc_test(
     "dynamic_config_test.cc",
   ],
   deps = [
+    "@com_google_absl//absl/memory:memory",
     "@com_google_googletest//:gtest_main",
     "//source:cpp2sky_lib",
     ":mocks",

--- a/test/buffer_test.cc
+++ b/test/buffer_test.cc
@@ -22,7 +22,7 @@ namespace cpp2sky {
 class CircularBufferTest : public testing::Test {
  protected:
   void setup(size_t size) {
-    buf_ = std::make_unique<CircularBuffer<int>>(size);
+    buf_ = absl::make_unique<CircularBuffer<int>>(size);
   }
 
   void evaluate(size_t expect_front, size_t expect_back, bool expect_empty) {

--- a/test/buffer_test.cc
+++ b/test/buffer_test.cc
@@ -15,6 +15,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/memory/memory.h"
 #include "source/utils/circular_buffer.h"
 
 namespace cpp2sky {

--- a/test/dynamic_config_test.cc
+++ b/test/dynamic_config_test.cc
@@ -17,6 +17,7 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include "absl/memory/memory.h"
 #include "common/Common.pb.h"
 
 namespace cpp2sky {
@@ -42,7 +43,7 @@ class DynamicConfigTest : public testing::Test {
     init_cfg_.set_service_name("mesh");
     init_cfg_.set_instance_name("instance_default");
 
-    dcfg_ = std::make_unique<DynamicConfig>(init_cfg_);
+    dcfg_ = absl::make_unique<DynamicConfig>(init_cfg_);
   }
 
   void update(skywalking::v3::Commands& commands) {

--- a/test/grpc_async_client_test.cc
+++ b/test/grpc_async_client_test.cc
@@ -30,11 +30,11 @@ class GrpcAsyncSegmentReporterClientTest : public testing::Test {
   GrpcAsyncSegmentReporterClientTest() {
     stream_ = std::make_shared<
         MockAsyncStream<TracerRequestType, TracerResponseType>>();
-    factory_ = std::make_unique<MockClientStreamingStreamBuilder<
+    factory_ = absl::make_unique<MockClientStreamingStreamBuilder<
         TracerRequestType, TracerResponseType>>(stream_);
     EXPECT_CALL(*factory_, create(_, _));
 
-    client_ = std::make_unique<GrpcAsyncSegmentReporterClient>(
+    client_ = absl::make_unique<GrpcAsyncSegmentReporterClient>(
         address_, cq_, std::move(factory_), grpc::InsecureChannelCredentials());
   }
 

--- a/test/grpc_async_client_test.cc
+++ b/test/grpc_async_client_test.cc
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include "absl/memory/memory.h"
 #include "language-agent/Tracing.pb.h"
 #include "source/grpc_async_client_impl.h"
 #include "test/mocks.h"

--- a/test/propagation_test.cc
+++ b/test/propagation_test.cc
@@ -15,25 +15,24 @@
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
-#include <string_view>
-
+#include "absl/strings/string_view.h"
 #include "cpp2sky/exception.h"
 #include "source/propagation_impl.h"
 
 namespace cpp2sky {
 
-static constexpr std::string_view sample =
+static constexpr absl::string_view sample =
     "1-MQ==-NQ==-3-bWVzaA==-aW5zdGFuY2U=-L2FwaS92MS9oZWFsdGg=-"
     "ZXhhbXBsZS5jb206ODA4MA==";
 
-static constexpr std::string_view less_field =
+static constexpr absl::string_view less_field =
     "1-MQ==-NQ==-3-bWVzaA==-aW5zdGFuY2U=-L2FwaS92MS9oZWFsdGg=";
 
-static constexpr std::string_view more_field =
+static constexpr absl::string_view more_field =
     "1-MQ==-NQ==-3-bWVzaA==-aW5zdGFuY2U=-L2FwaS92MS9oZWFsdGg=-"
     "ZXhhbXBsZS5jb206ODA4MA==-hogehoge";
 
-static constexpr std::string_view invalid_sample =
+static constexpr absl::string_view invalid_sample =
     "3-MQ==-NQ==-3-bWVzaA==-aW5zdGFuY2U=-L2FwaS92MS9oZWFsdGg=-"
     "ZXhhbXBsZS5jb206ODA4MA==";
 

--- a/test/tracer_test.cc
+++ b/test/tracer_test.cc
@@ -27,7 +27,7 @@ TEST(TracerTest, MatchedOpShouldIgnored) {
   *config.add_ignore_operation_name_suffix() = "/ignored";
 
   TracerImpl tracer(
-      config, std::make_unique<
+      config, absl::make_unique<
                   MockAsyncClient<TracerRequestType, TracerResponseType>>());
   auto context = tracer.newContext();
   auto span = context->createEntrySpan();
@@ -42,7 +42,7 @@ TEST(TracerTest, NotClosedSpanExists) {
   TracerConfig config;
 
   TracerImpl tracer(
-      config, std::make_unique<
+      config, absl::make_unique<
                   MockAsyncClient<TracerRequestType, TracerResponseType>>());
   auto context = tracer.newContext();
   auto span = context->createEntrySpan();
@@ -55,7 +55,7 @@ TEST(TracerTest, NotClosedSpanExists) {
 TEST(TracerTest, Success) {
   TracerConfig config;
 
-  auto mock_reporter = std::make_unique<
+  auto mock_reporter = absl::make_unique<
       MockAsyncClient<TracerRequestType, TracerResponseType>>();
   EXPECT_CALL(*mock_reporter, sendMessage(_));
 

--- a/test/tracing_context_test.cc
+++ b/test/tracing_context_test.cc
@@ -18,8 +18,8 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
 
+#include "absl/strings/string_view.h"
 #include "external/skywalking_data_collect_protocol/language-agent/Tracing.pb.h"
 #include "mocks.h"
 #include "source/propagation_impl.h"
@@ -31,7 +31,7 @@ using testing::Return;
 
 namespace cpp2sky {
 
-static constexpr std::string_view sample_ctx =
+static constexpr absl::string_view sample_ctx =
     "1-MQ==-NQ==-3-bWVzaA==-aW5zdGFuY2U=-L2FwaS92MS9oZWFsdGg=-"
     "ZXhhbXBsZS5jb206ODA4MA==";
 
@@ -44,7 +44,7 @@ class TracingContextTest : public testing::Test {
     span_ctx_ = std::make_shared<SpanContextImpl>(sample_ctx);
     span_ext_ctx_ = std::make_shared<SpanContextExtensionImpl>("1");
 
-    factory_ = std::make_unique<TracingContextFactory>(config_);
+    factory_ = absl::make_unique<TracingContextFactory>(config_);
   }
 
  protected:
@@ -191,8 +191,8 @@ TEST_F(TracingContextTest, ChildSegmentContext) {
   span_child->setPeer("localhost:9000");
   span_child->addTag("category", "database");
 
-  std::string_view key = "method";
-  std::string_view value = "GETxxxx";
+  absl::string_view key = "method";
+  absl::string_view value = "GETxxxx";
   value.remove_suffix(4);
   span_child->addTag(key, value);
 
@@ -202,8 +202,8 @@ TEST_F(TracingContextTest, ChildSegmentContext) {
       SystemTime(std::chrono::duration<int, std::milli>(300)));
   span_child->addLog(log_key, log_value, t3);
 
-  std::string_view log_key2 = "service_1";
-  std::string_view log_value2 = "succeeded\x01\x03";
+  absl::string_view log_key2 = "service_1";
+  absl::string_view log_value2 = "succeeded\x01\x03";
   log_value2.remove_suffix(2);
 
   auto t4 = TimePoint<SystemTime>(
@@ -341,7 +341,7 @@ TEST_F(TracingContextTest, SW8CreateTest) {
   target_address_based_vector = {'1', '0', '.', '0', '.', '0',
                                  '.', '1', ':', '4', '4', '3'};
 
-  std::string_view target_address_based_vector_view{
+  absl::string_view target_address_based_vector_view{
       target_address_based_vector.data(), target_address_based_vector.size()};
 
   EXPECT_EQ(target_address_based_vector.size(), target_address.size());


### PR DESCRIPTION
Signed-off-by: wangbaiping <wbphub@live.com>

```
std::make_unique (from c++14) -> absl::make_unique
std::string_view (from c++17) -> absl::string_view
std::optional (from c++17) -> absl::optional
std::nullopt (from c++17) -> absl::nullopt
```

`absl::string_view/absl::optional/absl::nullopt/...` will be alias of `std::string_view/std::optional/std::nullopt/...` after c++17 by default. So it's ok to always use the `absl::*` in c++11/c++14/c++17 versions.